### PR TITLE
Updated to Fall 2024 image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 // spell: disable
 {
 	"name": "Simple REST",
-	"image": "rofrano/nyu-devops-base:su24",
+	"image": "rofrano/nyu-devops-base:fa24",
 	"workspaceFolder": "/app",
     "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind,consistency=delegated",
 	"remoteUser": "vscode",
-    "runArgs": ["-h","nyu"],
+    "runArgs": ["-h","nyu","--name","lab-simple-rest"],
     "remoteEnv": {
 		"FLASK_APP": "app.py",
     	"FLASK_DEBUG": "True"


### PR DESCRIPTION
Made the following changes for the Fall 2024 semester:

- Updated the base image to the Fall 2024 NYU DevOps Base (`rofrano/nyu-devops-base:fa24`)
- Added the container name: `lab-simple-rest`